### PR TITLE
Add new release

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,12 +6,14 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { LoginComponent } from './authentication/login/login.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 import { NewsContainerComponent } from './news/containers/news-container/news-container.component';
+import { ShoesPageContainerComponent } from './shoes-page/shoes-page-container/shoes-page-container.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/news', pathMatch: 'full' },
   { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard] },  
   { path: 'news', component: NewsContainerComponent },
-  { path: 'login', component: UserProfileComponent }
+  { path: 'login', component: UserProfileComponent },
+  { path: 'shoes', component: ShoesPageContainerComponent }
 ];
 
 @NgModule({

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ const routes: Routes = [
   { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard] },  
   { path: 'news', component: NewsContainerComponent },
   { path: 'login', component: UserProfileComponent },
+  { path: 'profile', component: UserProfileComponent },
   { path: 'shoes', component: ShoesPageContainerComponent }
 ];
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -20,6 +20,7 @@
       <mat-icon class="account-icon">account_circle</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
+      <button mat-menu-item class="menu-button" routerLink="/profile">Profile</button>
       <button mat-menu-item class="menu-button" (click)="userLogOut()">Log out</button>
     </mat-menu>
   </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,18 +23,22 @@ import { SideNavComponent } from './side-nav/side-nav.component';
 //containers
 import { AddShoeContainerComponent } from './add-shoe/containers/add-shoe-container/add-shoe-container.component';
 import { ShoesCardsContainerComponent } from './shoes-cards/containers/shoes-cards-container/shoes-cards-container.component';
-import { ShoesCardsComponentComponent } from './shoes-cards/components/shoes-cards-component/shoes-cards-component.component';
+import { NewsContainerComponent } from './news/containers/news-container/news-container.component';
+import { NewReleaseShoeModalContainerComponent } from './news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component';
 
 //components
 import { AddShoeFormComponent } from './add-shoe/components/add-shoe-form/add-shoe-form.component';
 import { DeleteShoeModalComponent } from './delete-shoe-modal/delete-shoe-modal.component';
+import { NewsComponentComponent } from './news/components/news-component/news-component.component';
+import { ShoesCardsComponentComponent } from './shoes-cards/components/shoes-cards-component/shoes-cards-component.component';
+import { NewReleaseShoeModalComponent } from './news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component';
+
+import { UserProfileComponent } from './user-profile/user-profile.component';
+import { LoginComponent } from './authentication/login/login.component';
 
 //filter
 import { FilterPipe } from './filter.pipe';
-import { UserProfileComponent } from './user-profile/user-profile.component';
-import { LoginComponent } from './authentication/login/login.component';
-import { NewsContainerComponent } from './news/containers/news-container/news-container.component';
-import { NewsComponentComponent } from './news/components/news-component/news-component.component';
+
 
 
 @NgModule({
@@ -51,7 +55,9 @@ import { NewsComponentComponent } from './news/components/news-component/news-co
     UserProfileComponent,
     LoginComponent,
     NewsContainerComponent,
-    NewsComponentComponent
+    NewsComponentComponent,
+    NewReleaseShoeModalContainerComponent,
+    NewReleaseShoeModalComponent
   ],
   imports: [
     BrowserModule,
@@ -67,6 +73,7 @@ import { NewsComponentComponent } from './news/components/news-component/news-co
     FlexLayoutModule
   ],
   entryComponents: [
+    NewReleaseShoeModalContainerComponent,
     AddShoeContainerComponent,
     DeleteShoeModalComponent,
     LoginComponent

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,7 +38,8 @@ import { LoginComponent } from './authentication/login/login.component';
 
 //filter
 import { FilterPipe } from './filter.pipe';
-
+import { ShoesPageComponent } from './shoes-page/shoes-page-component/shoes-page.component';
+import { ShoesPageContainerComponent } from './shoes-page/shoes-page-container/shoes-page-container.component';
 
 
 @NgModule({
@@ -57,7 +58,9 @@ import { FilterPipe } from './filter.pipe';
     NewsContainerComponent,
     NewsComponentComponent,
     NewReleaseShoeModalContainerComponent,
-    NewReleaseShoeModalComponent
+    NewReleaseShoeModalComponent,
+    ShoesPageComponent,
+    ShoesPageContainerComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/authentication/auth-service.service.ts
+++ b/src/app/authentication/auth-service.service.ts
@@ -59,4 +59,8 @@ export class AuthService {
 
   }
 
+  public getUserData() {
+    return this.afAuth.auth.currentUser;
+  }
+
 }

--- a/src/app/authentication/login/login.component.ts
+++ b/src/app/authentication/login/login.component.ts
@@ -25,7 +25,7 @@ export class LoginComponent implements OnInit {
 
   printUser(event) {
     this.dialogRef.close();
-    this.router.navigate(['/dashboard']);
+    this.router.navigate(['/news']);
   }
 
   printError(event) {

--- a/src/app/delete-shoe-modal/delete-shoe-modal.component.ts
+++ b/src/app/delete-shoe-modal/delete-shoe-modal.component.ts
@@ -26,7 +26,7 @@ export class DeleteShoeModalComponent implements OnInit {
   }
 
   handleDelete(id: string): void {
-    this.shoeService.deleteShoe(id);
+    this.shoeService.deleteShoeNews(id);
     this.dialogRef.close();
   }
 

--- a/src/app/models/new-release.interface.ts
+++ b/src/app/models/new-release.interface.ts
@@ -1,9 +1,9 @@
 export interface NewRelease {
+    brand: string;
     name: string;
     subName: string;
-    releaseDate: string;
-    brand: string;
-    site: string;
     photoLink: string;
+    releaseDate: string;
+    site: string;
 }
   

--- a/src/app/models/new-release.interface.ts
+++ b/src/app/models/new-release.interface.ts
@@ -3,7 +3,7 @@ export interface NewRelease {
     name: string;
     subName: string;
     photoLink: string;
-    releaseDate: string;
+    releaseDate: Date;
     site: string;
 }
   

--- a/src/app/models/new-release.interface.ts
+++ b/src/app/models/new-release.interface.ts
@@ -1,6 +1,6 @@
 export interface NewRelease {
     releaseDate: Date;
-    releaseSites: Object;
+    releaseSites: Array<NewReleaseSites>;
     shoeDetails: Object;
 }
 
@@ -15,8 +15,8 @@ export interface NewReleaseShoeDetail {
     brand: string;
     name: string;
     subName: string;
-    realeaseSizes: number;
     price: number;
+    releaseSizes: Object;
     photoLink: string;
 }
   

--- a/src/app/models/new-release.interface.ts
+++ b/src/app/models/new-release.interface.ts
@@ -1,9 +1,22 @@
 export interface NewRelease {
+    releaseDate: Date;
+    releaseSites: Object;
+    shoeDetails: Object;
+}
+
+export interface NewReleaseSites {
+    dropType: string;
+    siteName: string;
+    siteLink: string;
+    dropTime: string;
+}
+
+export interface NewReleaseShoeDetail {
     brand: string;
     name: string;
     subName: string;
+    realeaseSizes: number;
+    price: number;
     photoLink: string;
-    releaseDate: Date;
-    site: string;
 }
   

--- a/src/app/models/new-release.interface.ts
+++ b/src/app/models/new-release.interface.ts
@@ -1,5 +1,5 @@
 export interface NewRelease {
-    releaseDate: Date;
+    releaseDate;
     releaseSites: Array<NewReleaseSites>;
     shoeDetails: NewReleaseShoeDetail;
 }

--- a/src/app/models/new-release.interface.ts
+++ b/src/app/models/new-release.interface.ts
@@ -1,7 +1,7 @@
 export interface NewRelease {
     releaseDate: Date;
     releaseSites: Array<NewReleaseSites>;
-    shoeDetails: Object;
+    shoeDetails: NewReleaseShoeDetail;
 }
 
 export interface NewReleaseSites {

--- a/src/app/models/shoes.interface.ts
+++ b/src/app/models/shoes.interface.ts
@@ -1,6 +1,7 @@
 export interface Shoe {
     id: string;
     name: string;
+    subName: string;
     year: number;
     brand: string;
     size: number;

--- a/src/app/news/components/news-component/news-component.component.html
+++ b/src/app/news/components/news-component/news-component.component.html
@@ -5,13 +5,13 @@
 
 <div class="card-layout">
   <mat-card class="shoe-cards" *ngFor="let shoe of releaseDetail | async">
-    <mat-card-header (click)="onClickCard()">
+    <mat-card-header (click)="onClickCard(shoe.id)">
       <div mat-card-avatar class="example-header-image"></div>
       <mat-card-title>{{shoe.name}}</mat-card-title>
       <mat-card-subtitle>{{shoe.subName}}</mat-card-subtitle>
     </mat-card-header>
-    <img (click)="onClickCard()" mat-card-image src="{{shoe.photoLink}}" alt="shoe image">
-    <mat-card-content (click)="onClickCard()">
+    <img (click)="onClickCard(shoe.id)" mat-card-image src="{{shoe.photoLink}}" alt="shoe image">
+    <mat-card-content (click)="onClickCard(shoe.id)">
       <dl>
         <dt class="mat-small">Release Date</dt>
         <dd class="mat-body-2">{{shoe.releaseDate.toDate() | date: 'MM/dd/yyyy'}}</dd>

--- a/src/app/news/components/news-component/news-component.component.html
+++ b/src/app/news/components/news-component/news-component.component.html
@@ -7,16 +7,16 @@
   <mat-card class="shoe-cards" *ngFor="let shoe of releaseDetail | async">
     <mat-card-header (click)="onClickCard(shoe.id)">
       <div mat-card-avatar class="example-header-image"></div>
-      <mat-card-title>{{shoe.name}}</mat-card-title>
-      <mat-card-subtitle>{{shoe.subName}}</mat-card-subtitle>
+      <mat-card-title>{{shoe.shoeDetails.name}}</mat-card-title>
+      <mat-card-subtitle>{{shoe.shoeDetails.subName}}</mat-card-subtitle>
     </mat-card-header>
-    <img (click)="onClickCard(shoe.id)" mat-card-image src="{{shoe.photoLink}}" alt="shoe image">
+    <img (click)="onClickCard(shoe.id)" mat-card-image src="{{shoe.shoeDetails.photoLink}}" alt="shoe image">
     <mat-card-content (click)="onClickCard(shoe.id)">
       <dl>
         <dt class="mat-small">Release Date</dt>
         <dd class="mat-body-2">{{shoe.releaseDate.toDate() | date: 'MM/dd/yyyy'}}</dd>
-        <dt class="mat-small">Site</dt>
-        <dd class="mat-body-2">{{shoe.site}}</dd>
+        <dt class="mat-small">Price</dt>
+        <dd class="mat-body-2">{{shoe.shoeDetails.price | currency}}</dd>
       </dl>
     </mat-card-content>
     <mat-card-actions>

--- a/src/app/news/components/news-component/news-component.component.html
+++ b/src/app/news/components/news-component/news-component.component.html
@@ -1,27 +1,27 @@
+<button class="create-shoe-btn" color="warn" (click)="openAddShoeModal(null, null, false)" mat-raised-button>Add Shoe +</button>
 <h1>
-  June
+  January
 </h1>
 
 <div class="card-layout">
-  <mat-card class="shoe-cards" *ngFor="let shoe of releaseDetail | async">
+  <mat-card (click)="onClickCard()" class="shoe-cards" *ngFor="let shoe of releaseDetail | async">
     <mat-card-header>
       <div mat-card-avatar class="example-header-image"></div>
       <mat-card-title>{{shoe.name}}</mat-card-title>
       <mat-card-subtitle>{{shoe.subName}}</mat-card-subtitle>
     </mat-card-header>
     <img mat-card-image src="{{shoe.photoLink}}" alt="shoe image">
-    <mat-card-content >
+    <mat-card-content>
       <dl>
         <dt class="mat-small">Release Date</dt>
         <dd class="mat-body-2">{{shoe.releaseDate}}</dd>
-        <!-- <dt class="mat-small">Time</dt>
-        <dd class="mat-body-2">10:00 AM</dd> -->
         <dt class="mat-small">Site</dt>
         <dd class="mat-body-2">{{shoe.site}}</dd>
       </dl>
     </mat-card-content>
-    <!-- <mat-card-actions>
-      <button mat-button (click)="collapsed=!collapsed">Show more</button>
+    <!-- like icon
+    <mat-card-actions>
+      <button mat-mini-fab color="warn"><mat-icon>favorite</mat-icon></button>
     </mat-card-actions> -->
   </mat-card>
 </div>

--- a/src/app/news/components/news-component/news-component.component.html
+++ b/src/app/news/components/news-component/news-component.component.html
@@ -4,25 +4,25 @@
 </h1>
 
 <div class="card-layout">
-  <mat-card (click)="onClickCard()" class="shoe-cards" *ngFor="let shoe of releaseDetail | async">
-    <mat-card-header>
+  <mat-card class="shoe-cards" *ngFor="let shoe of releaseDetail | async">
+    <mat-card-header (click)="onClickCard()">
       <div mat-card-avatar class="example-header-image"></div>
       <mat-card-title>{{shoe.name}}</mat-card-title>
       <mat-card-subtitle>{{shoe.subName}}</mat-card-subtitle>
     </mat-card-header>
-    <img mat-card-image src="{{shoe.photoLink}}" alt="shoe image">
-    <mat-card-content>
+    <img (click)="onClickCard()" mat-card-image src="{{shoe.photoLink}}" alt="shoe image">
+    <mat-card-content (click)="onClickCard()">
       <dl>
         <dt class="mat-small">Release Date</dt>
-        <dd class="mat-body-2">{{shoe.releaseDate}}</dd>
+        <dd class="mat-body-2">{{shoe.releaseDate.toDate() | date: 'MM/dd/yyyy'}}</dd>
         <dt class="mat-small">Site</dt>
         <dd class="mat-body-2">{{shoe.site}}</dd>
       </dl>
     </mat-card-content>
-    <!-- like icon
     <mat-card-actions>
-      <button mat-mini-fab color="warn"><mat-icon>favorite</mat-icon></button>
-    </mat-card-actions> -->
+      <button class="" (click)="openAddShoeModal(shoe.id, shoe.name, true)" mat-button>Edit</button>
+      <button class="" (click)="deleteShoe(shoe.id, shoe.name)" mat-button>Delete</button>
+    </mat-card-actions>
   </mat-card>
 </div>
 

--- a/src/app/news/components/news-component/news-component.component.html
+++ b/src/app/news/components/news-component/news-component.component.html
@@ -20,8 +20,8 @@
       </dl>
     </mat-card-content>
     <mat-card-actions>
-      <button class="" (click)="openAddShoeModal(shoe.id, shoe.name, true)" mat-button>Edit</button>
-      <button class="" (click)="deleteShoe(shoe.id, shoe.name)" mat-button>Delete</button>
+      <button (click)="openAddShoeModal(shoe.id, shoe.name, true)" color="primary" mat-button>Edit</button>
+      <button (click)="deleteShoe(shoe.id, shoe.name)" color="warn" mat-button>Delete</button>
     </mat-card-actions>
   </mat-card>
 </div>

--- a/src/app/news/components/news-component/news-component.component.scss
+++ b/src/app/news/components/news-component/news-component.component.scss
@@ -1,11 +1,32 @@
+mat-card {
+  width: 250px;
+}
+
+mat-card:hover {
+  background-color: #fafafa;
+  cursor: pointer;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+}
+  
+dd {
+    margin-inline-start: 0;
+}
+
 .card-layout {
   display: grid;
   grid-gap: 10px;
   grid-template-columns: repeat(auto-fill, 280px);
 }
 
-.shoe-card {
-  max-width: 230px;
+.shoe-cards {
+  // max-width: 230px;
+  :hover {
+    background-color: red($color: #000000);
+  }
 }
   
 .example-header-image {
@@ -13,19 +34,7 @@
     background-size: cover;
 }
 
-mat-card {
-  width: 240px;
-}
 
 [mat-card-image] {
   height: 180px;
-}
-
-dl {
-    display: grid;
-    grid-template-columns: 2fr 3fr;
-  }
-  
-dd {
-    margin-inline-start: 0;
 }

--- a/src/app/news/components/news-component/news-component.component.ts
+++ b/src/app/news/components/news-component/news-component.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { MediaMatcher } from '@angular/cdk/layout';
 import { MatDialog } from '@angular/material';
+import { Router } from '@angular/router';
 
 import { NewReleaseShoeModalContainerComponent } from '../../new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component';
 import { DeleteShoeModalComponent } from '../../../delete-shoe-modal/delete-shoe-modal.component';
@@ -24,7 +25,7 @@ export class NewsComponentComponent implements OnInit {
   mobileQuery: MediaQueryList;
   collapsed = true;
 
-  constructor(media: MediaMatcher, public dialog: MatDialog, public authService: AuthService) {
+  constructor(media: MediaMatcher, public dialog: MatDialog, public authService: AuthService, public router: Router) {
     this.mobileQuery = media.matchMedia('(max-width: 600px)');
   }
 
@@ -42,7 +43,7 @@ export class NewsComponentComponent implements OnInit {
   }
   
   onClickCard(id: string) {
-    console.log(id);
+    this.router.navigate(['/shoes'], { queryParams: { shoeId: id } });
   }
 
   deleteShoe(id: string, name: string) {

--- a/src/app/news/components/news-component/news-component.component.ts
+++ b/src/app/news/components/news-component/news-component.component.ts
@@ -2,7 +2,10 @@ import { Component, OnInit, Input } from '@angular/core';
 import { MediaMatcher } from '@angular/cdk/layout';
 import { MatDialog } from '@angular/material';
 
-import{ NewReleaseShoeModalContainerComponent } from '../../new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component';
+import { NewReleaseShoeModalContainerComponent } from '../../new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component';
+import { DeleteShoeModalComponent } from '../../../delete-shoe-modal/delete-shoe-modal.component';
+
+import { AuthService } from '../../../authentication/auth-service.service';
 
 import { NewRelease } from '../../../models/new-release.interface';
 
@@ -15,15 +18,17 @@ export class NewsComponentComponent implements OnInit {
 
   @Input()
   releaseDetail: NewRelease;
+
+  @Input()
+  userModel;
   
   private _mobileQueryListener: () => void;
 
   mobileQuery: MediaQueryList;
-
-
   collapsed = true;
+  user;
 
-  constructor(media: MediaMatcher, public dialog: MatDialog) {
+  constructor(media: MediaMatcher, public dialog: MatDialog, public authService: AuthService) {
     this.mobileQuery = media.matchMedia('(max-width: 600px)');
   }
   
@@ -31,15 +36,28 @@ export class NewsComponentComponent implements OnInit {
   ngOnInit() {
   }
 
+  ngOnChanges() {
+    console.log(this.userModel);
+  }
+
   openAddShoeModal(id: string, name: string, edit: boolean): void {
     const dialogRef = this.dialog.open(NewReleaseShoeModalContainerComponent, {
-      width: '380px',
+      width: '500px',
       data: {id: id, shoeName: name, isEdit: edit}
     });
   }
 
   onClickCard() {
+    this.user = this.authService.getUserData();
+    console.log(this.user);
     console.log('modal click');
+  }
+
+  deleteShoe(id: string, name: string) {
+    const dialogRef = this.dialog.open(DeleteShoeModalComponent, {
+      width: '380px',
+      data: {id: id, shoeName: name}
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/news/components/news-component/news-component.component.ts
+++ b/src/app/news/components/news-component/news-component.component.ts
@@ -23,12 +23,10 @@ export class NewsComponentComponent implements OnInit {
 
   mobileQuery: MediaQueryList;
   collapsed = true;
-  user;
 
   constructor(media: MediaMatcher, public dialog: MatDialog, public authService: AuthService) {
     this.mobileQuery = media.matchMedia('(max-width: 600px)');
   }
-  
 
   ngOnInit() {
   }

--- a/src/app/news/components/news-component/news-component.component.ts
+++ b/src/app/news/components/news-component/news-component.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { MatDialog } from '@angular/material';
+
+import{ NewReleaseShoeModalContainerComponent } from '../../new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component';
 
 import { NewRelease } from '../../../models/new-release.interface';
 
@@ -11,12 +15,35 @@ export class NewsComponentComponent implements OnInit {
 
   @Input()
   releaseDetail: NewRelease;
+  
+  private _mobileQueryListener: () => void;
+
+  mobileQuery: MediaQueryList;
+
 
   collapsed = true;
 
-  constructor() { }
+  constructor(media: MediaMatcher, public dialog: MatDialog) {
+    this.mobileQuery = media.matchMedia('(max-width: 600px)');
+  }
+  
 
   ngOnInit() {
+  }
+
+  openAddShoeModal(id: string, name: string, edit: boolean): void {
+    const dialogRef = this.dialog.open(NewReleaseShoeModalContainerComponent, {
+      width: '380px',
+      data: {id: id, shoeName: name, isEdit: edit}
+    });
+  }
+
+  onClickCard() {
+    console.log('modal click');
+  }
+
+  ngOnDestroy(): void {
+    this.mobileQuery.removeListener(this._mobileQueryListener);
   }
 
 }

--- a/src/app/news/components/news-component/news-component.component.ts
+++ b/src/app/news/components/news-component/news-component.component.ts
@@ -19,9 +19,6 @@ export class NewsComponentComponent implements OnInit {
   @Input()
   releaseDetail: NewRelease;
 
-  @Input()
-  userModel;
-  
   private _mobileQueryListener: () => void;
 
   mobileQuery: MediaQueryList;
@@ -35,22 +32,19 @@ export class NewsComponentComponent implements OnInit {
 
   ngOnInit() {
   }
-
+  
   ngOnChanges() {
-    console.log(this.userModel);
   }
-
+  
   openAddShoeModal(id: string, name: string, edit: boolean): void {
     const dialogRef = this.dialog.open(NewReleaseShoeModalContainerComponent, {
       width: '500px',
       data: {id: id, shoeName: name, isEdit: edit}
     });
   }
-
-  onClickCard() {
-    this.user = this.authService.getUserData();
-    console.log(this.user);
-    console.log('modal click');
+  
+  onClickCard(id: string) {
+    console.log(id);
   }
 
   deleteShoe(id: string, name: string) {

--- a/src/app/news/containers/news-container/news-container.component.html
+++ b/src/app/news/containers/news-container/news-container.component.html
@@ -1,6 +1,5 @@
 <div class="news">
   <app-news-component
-    [releaseDetail]="newRelease"
-    [userModel]="user">
+    [releaseDetail]="newRelease">
   </app-news-component>
 </div>

--- a/src/app/news/containers/news-container/news-container.component.html
+++ b/src/app/news/containers/news-container/news-container.component.html
@@ -1,5 +1,6 @@
 <div class="news">
   <app-news-component
-    [releaseDetail]="newRelease">
+    [releaseDetail]="newRelease"
+    [userModel]="user">
   </app-news-component>
 </div>

--- a/src/app/news/containers/news-container/news-container.component.ts
+++ b/src/app/news/containers/news-container/news-container.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
+
 import { ShoeService } from '../../../shoes-service/shoe.service';
+import { AuthService } from '../../../authentication/auth-service.service';
+
 import { NewRelease } from '../../../models/new-release.interface';
 
 @Component({
@@ -11,12 +14,17 @@ import { NewRelease } from '../../../models/new-release.interface';
 export class NewsContainerComponent implements OnInit {
 
   newRelease: Observable<any[]>;
+  user;
 
   constructor(
-    private shoeService: ShoeService) { }
+    private shoeService: ShoeService,
+    private authService: AuthService) { }
 
   ngOnInit() {
       this.newRelease = this.shoeService.getShoesNews();
+
+      //todo..user info loads after ngOnInit(bug)
+      this.user = this.authService.getUserData();
   }
 
 }

--- a/src/app/news/containers/news-container/news-container.component.ts
+++ b/src/app/news/containers/news-container/news-container.component.ts
@@ -14,7 +14,6 @@ import { NewRelease } from '../../../models/new-release.interface';
 export class NewsContainerComponent implements OnInit {
 
   newRelease: Observable<any[]>;
-  user;
 
   constructor(
     private shoeService: ShoeService,
@@ -22,9 +21,6 @@ export class NewsContainerComponent implements OnInit {
 
   ngOnInit() {
       this.newRelease = this.shoeService.getShoesNews();
-
-      //todo..user info loads after ngOnInit(bug)
-      this.user = this.authService.getUserData();
   }
 
 }

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
@@ -3,45 +3,45 @@
   <div class="add-shoes-container" mat-dialog-content>
     <mat-form-field class="brand">
       <input
-          placeholder="Brand"
-          type="text"
-          name="brand"
-          #brand="ngModel"
-          [ngModel]="detail?.brand"
-          matInput
-          required>
+        placeholder="Brand"
+        type="text"
+        name="brand"
+        #brand="ngModel"
+        [ngModel]="detail?.brand"
+        matInput
+        required>
       <mat-error *ngIf="brand.errors?.required && brand.dirty">You must enter a value</mat-error>
     </mat-form-field>
       <mat-form-field class="name">
         <input
-            placeholder="Shoes Name"
-            type="text"
-            name="name"
-            #name="ngModel"
-            [ngModel]="detail?.name"
-            matInput
-            required>
+          placeholder="Shoes Name"
+          type="text"
+          name="name"
+          #name="ngModel"
+          [ngModel]="detail?.name"
+          matInput
+          required>
         <mat-error *ngIf="name.errors?.required && name.dirty">You must enter a value</mat-error>
       </mat-form-field>
       <mat-form-field class="subName">
         <input
-            placeholder="Shoe Sub Name"
-            type="text"
-            name="subName"
-            #name="ngModel"
-            [ngModel]="detail?.subName"
-            matInput
-            required>
+          placeholder="Shoe Sub Name"
+          type="text"
+          name="subName"
+          #name="ngModel"
+          [ngModel]="detail?.subName"
+          matInput
+          required>
       </mat-form-field>
       <mat-form-field class="photoLink">
-          <input
-            placeholder="Photo Link"
-            type="text"
-            name="photoLink"
-            #photo="ngModel"
-            [ngModel]="detail?.photoLink"
-            matInput
-            required>
+        <input
+          placeholder="Photo Link"
+          type="text"
+          name="photoLink"
+          #photo="ngModel"
+          [ngModel]="detail?.photoLink"
+          matInput
+          required>
       </mat-form-field>
       <mat-form-field class="releaseDate">
         <input 

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
@@ -1,0 +1,74 @@
+<h1 mat-dialog-title>New Release Info</h1>
+<form #form="ngForm" (ngSubmit)="handleSubmit(form.value, form.valid)" novalidate>
+  <div class="add-shoes-container" mat-dialog-content>
+    <mat-form-field class="brand">
+      <input
+          placeholder="Brand"
+          type="text"
+          name="brand"
+          #brand="ngModel"
+          [ngModel]="detail?.brand"
+          matInput
+          required>
+      <mat-error *ngIf="brand.errors?.required && brand.dirty">You must enter a value</mat-error>
+    </mat-form-field>
+      <mat-form-field class="name">
+        <input
+            placeholder="Shoes Name"
+            type="text"
+            name="name"
+            #name="ngModel"
+            [ngModel]="detail?.name"
+            matInput
+            required>
+        <mat-error *ngIf="name.errors?.required && name.dirty">You must enter a value</mat-error>
+      </mat-form-field>
+      <mat-form-field class="subName">
+        <input
+            placeholder="Shoe Sub Name"
+            type="text"
+            name="subName"
+            #name="ngModel"
+            [ngModel]="detail?.subName"
+            matInput
+            required>
+      </mat-form-field>
+      <mat-form-field class="photoLink">
+          <input
+            placeholder="Photo Link"
+            type="text"
+            name="photoLink"
+            #photo="ngModel"
+            [ngModel]="detail?.photoLink"
+            matInput
+            required>
+      </mat-form-field>
+      <mat-form-field class="releaseDate">
+        <input 
+          matInput 
+          [matDatepicker]="picker" 
+          name="releaseDate"
+          [ngModel]="detail?.releaseDate"
+          placeholder="Choose a relese date">
+        <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+        <mat-datepicker #picker></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field class="site">
+        <input
+          placeholder="Site Links"
+          type="text"
+          name="site"
+          #photo="ngModel"
+          [ngModel]="detail?.site"
+          matInput
+          required>
+    </mat-form-field>
+  </div>
+  <div mat-dialog-actions>
+    <span class="btn-spacer"></span>
+    <button (click)="onNoClick()" mat-flat-button>Cancel</button>
+    <button color="primary" type="submit" [disabled]="form.invalid" mat-flat-button>
+      Submit
+    </button>
+  </div>
+</form>

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
@@ -7,7 +7,7 @@
         type="text"
         name="brand"
         #brand="ngModel"
-        [ngModel]="detail?.brand"
+        [ngModel]="shoesModel?.brand"
         matInput
         required>
       <mat-error *ngIf="brand.errors?.required && brand.dirty">You must enter a value</mat-error>
@@ -18,7 +18,7 @@
           type="text"
           name="name"
           #name="ngModel"
-          [ngModel]="detail?.name"
+          [ngModel]="shoesModel?.name"
           matInput
           required>
         <mat-error *ngIf="name.errors?.required && name.dirty">You must enter a value</mat-error>
@@ -29,7 +29,7 @@
           type="text"
           name="subName"
           #name="ngModel"
-          [ngModel]="detail?.subName"
+          [ngModel]="shoesModel?.subName"
           matInput
           required>
       </mat-form-field>
@@ -39,7 +39,7 @@
           type="text"
           name="photoLink"
           #photo="ngModel"
-          [ngModel]="detail?.photoLink"
+          [ngModel]="shoesModel?.photoLink"
           matInput
           required>
       </mat-form-field>
@@ -48,7 +48,7 @@
           matInput 
           [matDatepicker]="picker" 
           name="releaseDate"
-          [ngModel]="detail?.releaseDate"
+          [ngModel]="shoesModel?.releaseDate"
           placeholder="Choose a relese date">
         <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>
@@ -59,7 +59,7 @@
           type="text"
           name="site"
           #photo="ngModel"
-          [ngModel]="detail?.site"
+          [ngModel]="shoesModel?.site"
           matInput
           required>
     </mat-form-field>

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.html
@@ -1,73 +1,64 @@
 <h1 mat-dialog-title>New Release Info</h1>
-<form #form="ngForm" (ngSubmit)="handleSubmit(form.value, form.valid)" novalidate>
-  <div class="add-shoes-container" mat-dialog-content>
-    <mat-form-field class="brand">
-      <input
-        placeholder="Brand"
-        type="text"
-        name="brand"
-        #brand="ngModel"
-        [ngModel]="shoesModel?.brand"
-        matInput
-        required>
-      <mat-error *ngIf="brand.errors?.required && brand.dirty">You must enter a value</mat-error>
+<form [formGroup]="newReleaseShoeForm" (ngSubmit)="handleSubmit(newReleaseShoeForm.value, newReleaseShoeForm.valid)" novalidate>
+  <div mat-dialog-content>
+    <mat-form-field class="releaseDate">
+      <input 
+        matInput 
+        [matDatepicker]="picker"
+        formControlName="releaseDate"
+        placeholder="Choose a relese date">
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-datepicker #picker></mat-datepicker>
     </mat-form-field>
+    <div class="add-shoes-container" formGroupName="shoeDetails">
+      <mat-form-field class="brand">
+        <input
+          placeholder="Brand Name"
+          type="text"
+          formControlName="brand"
+          matInput
+          required>
+      </mat-form-field>
       <mat-form-field class="name">
         <input
           placeholder="Shoes Name"
           type="text"
-          name="name"
-          #name="ngModel"
-          [ngModel]="shoesModel?.name"
+          formControlName="name"
           matInput
           required>
-        <mat-error *ngIf="name.errors?.required && name.dirty">You must enter a value</mat-error>
       </mat-form-field>
       <mat-form-field class="subName">
         <input
-          placeholder="Shoe Sub Name"
+          placeholder="Sub Name"
           type="text"
-          name="subName"
-          #name="ngModel"
-          [ngModel]="shoesModel?.subName"
+          formControlName="subName"
           matInput
           required>
+      </mat-form-field>
+      <mat-form-field class="price">
+        <input
+          placeholder="Price"
+          type="number"
+          formControlName="price"
+          matInput
+          required>
+          <span matPrefix>$&nbsp;</span>
+          <span matSuffix>.00</span>
       </mat-form-field>
       <mat-form-field class="photoLink">
         <input
           placeholder="Photo Link"
           type="text"
-          name="photoLink"
-          #photo="ngModel"
-          [ngModel]="shoesModel?.photoLink"
+          formControlName="photoLink"
           matInput
           required>
       </mat-form-field>
-      <mat-form-field class="releaseDate">
-        <input 
-          matInput 
-          [matDatepicker]="picker" 
-          name="releaseDate"
-          [ngModel]="shoesModel?.releaseDate"
-          placeholder="Choose a relese date">
-        <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-datepicker #picker></mat-datepicker>
-      </mat-form-field>
-      <mat-form-field class="site">
-        <input
-          placeholder="Site Links"
-          type="text"
-          name="site"
-          #photo="ngModel"
-          [ngModel]="shoesModel?.site"
-          matInput
-          required>
-    </mat-form-field>
+    </div>
   </div>
   <div mat-dialog-actions>
     <span class="btn-spacer"></span>
     <button (click)="onNoClick()" mat-flat-button>Cancel</button>
-    <button color="primary" type="submit" [disabled]="form.invalid" mat-flat-button>
+    <button color="primary" type="submit" [disabled]="newReleaseShoeForm.invalid" mat-flat-button>
       Submit
     </button>
   </div>

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.scss
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.scss
@@ -1,0 +1,12 @@
+.add-shoes-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.add-shoes-container > * {
+  width: 100%;
+}
+
+.btn-spacer {
+    flex: 1 1 auto;
+}

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.spec.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewReleaseShoeModalComponent } from './new-release-shoe-modal-component.component';
+
+describe('NewReleaseShoeModalComponent', () => {
+  let component: NewReleaseShoeModalComponent;
+  let fixture: ComponentFixture<NewReleaseShoeModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NewReleaseShoeModalComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewReleaseShoeModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -33,6 +33,7 @@ export class NewReleaseShoeModalComponent implements OnInit {
   updateFormValues() {
     if(this.shoesModel) {
       this.newReleaseShoeForm.setValue({
+        //todo...fix this part
         releaseDate: this.shoesModel.releaseDate.toDate(),
         shoeDetails: {
           brand: this.shoesModel.shoeDetails.brand,

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -21,7 +21,6 @@ export class NewReleaseShoeModalComponent implements OnInit {
 
   newReleaseShoeForm = new FormGroup({
     releaseDate: new FormControl(''),
-    releaseSites: new FormArray([]),
     shoeDetails: new FormGroup({
       brand: new FormControl(''),
       name: new FormControl(''),
@@ -30,6 +29,21 @@ export class NewReleaseShoeModalComponent implements OnInit {
       photoLink:new FormControl('')
     }),
   })
+  
+  updateFormValues() {
+    if(this.shoesModel) {
+      this.newReleaseShoeForm.setValue({
+        releaseDate: this.shoesModel.releaseDate.toDate(),
+        shoeDetails: {
+          brand: this.shoesModel.shoeDetails.brand,
+          name: this.shoesModel.shoeDetails.name,
+          subName: this.shoesModel.shoeDetails.subName,
+          price: this.shoesModel.shoeDetails.price,
+          photoLink: this.shoesModel.shoeDetails.photoLink
+        }
+      })
+    }
+  }
 
   constructor(public dialogRef: MatDialogRef<NewReleaseShoeModalContainerComponent>) {}
   
@@ -37,9 +51,7 @@ export class NewReleaseShoeModalComponent implements OnInit {
   }
 
   ngOnChanges() {
-    // todo....date not working
-    // this.date = this.shoesModel.releaseDate.toDate();
-    // this.shoesModel.releaseDate = this.date;
+    this.updateFormValues();
   }
 
   onNoClick(): void {

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -20,7 +20,7 @@ export class NewReleaseShoeModalComponent implements OnInit {
   update: EventEmitter<NewRelease> = new EventEmitter<NewRelease>();
 
   newReleaseShoeForm = new FormGroup({
-    releaseDate: new FormControl(),
+    releaseDate: new FormControl(''),
     releaseSites: new FormArray([]),
     shoeDetails: new FormGroup({
       brand: new FormControl(''),

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit, Input, Output, EventEmitter  } from '@angular/core';
+import { MatDialogRef } from '@angular/material';
+
+import { NewReleaseShoeModalContainerComponent } from '../../containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component';
+
+import { NewRelease } from '../../../../models/new-release.interface';
+
+@Component({
+  selector: 'app-new-release-shoe-modal-component',
+  templateUrl: './new-release-shoe-modal-component.component.html',
+  styleUrls: ['./new-release-shoe-modal-component.component.scss']
+})
+export class NewReleaseShoeModalComponent implements OnInit {
+  @Input()
+  detail: NewRelease;
+
+  @Output()
+  update: EventEmitter<NewRelease> = new EventEmitter<NewRelease>();
+
+  constructor(public dialogRef: MatDialogRef<NewReleaseShoeModalContainerComponent>) {}
+  
+  ngOnInit() {
+  }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  handleSubmit(shoe: NewRelease, isValid: boolean) {
+
+    if(isValid) {
+      this.update.emit(shoe);
+      this.dialogRef.close();
+    }
+    
+  }
+
+}

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -12,7 +12,7 @@ import { NewRelease } from '../../../../models/new-release.interface';
 })
 export class NewReleaseShoeModalComponent implements OnInit {
   @Input()
-  detail: NewRelease;
+  shoesModel: NewRelease;
 
   @Output()
   update: EventEmitter<NewRelease> = new EventEmitter<NewRelease>();
@@ -24,8 +24,8 @@ export class NewReleaseShoeModalComponent implements OnInit {
 
   ngOnChanges() {
     // todo....date not working
-    // this.date = this.detail.releaseDate.toDate();
-    // this.detail.releaseDate = this.date;
+    // this.date = this.shoesModel.releaseDate.toDate();
+    // this.shoesModel.releaseDate = this.date;
   }
 
   onNoClick(): void {

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -5,6 +5,8 @@ import { NewReleaseShoeModalContainerComponent } from '../../containers/new-rele
 
 import { NewRelease } from '../../../../models/new-release.interface';
 
+import { FormGroup, FormControl, FormArray } from '@angular/forms';
+
 @Component({
   selector: 'app-new-release-shoe-modal-component',
   templateUrl: './new-release-shoe-modal-component.component.html',
@@ -16,6 +18,18 @@ export class NewReleaseShoeModalComponent implements OnInit {
 
   @Output()
   update: EventEmitter<NewRelease> = new EventEmitter<NewRelease>();
+
+  newReleaseShoeForm = new FormGroup({
+    releaseDate: new FormControl(),
+    releaseSites: new FormArray([]),
+    shoeDetails: new FormGroup({
+      brand: new FormControl(''),
+      name: new FormControl(''),
+      subName: new FormControl(''),
+      price: new FormControl(''),
+      photoLink:new FormControl('')
+    }),
+  })
 
   constructor(public dialogRef: MatDialogRef<NewReleaseShoeModalContainerComponent>) {}
   

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -33,7 +33,6 @@ export class NewReleaseShoeModalComponent implements OnInit {
   updateFormValues() {
     if(this.shoesModel) {
       this.newReleaseShoeForm.setValue({
-        //todo...fix this part
         releaseDate: this.shoesModel.releaseDate.toDate(),
         shoeDetails: {
           brand: this.shoesModel.shoeDetails.brand,

--- a/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
+++ b/src/app/news/new-release-shoe-modal/components/new-release-shoe-modal-component/new-release-shoe-modal-component.component.ts
@@ -22,17 +22,21 @@ export class NewReleaseShoeModalComponent implements OnInit {
   ngOnInit() {
   }
 
+  ngOnChanges() {
+    // todo....date not working
+    // this.date = this.detail.releaseDate.toDate();
+    // this.detail.releaseDate = this.date;
+  }
+
   onNoClick(): void {
     this.dialogRef.close();
   }
 
   handleSubmit(shoe: NewRelease, isValid: boolean) {
-
     if(isValid) {
       this.update.emit(shoe);
       this.dialogRef.close();
     }
-    
   }
 
 }

--- a/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.html
+++ b/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.html
@@ -1,0 +1,6 @@
+<div>
+  <app-new-release-shoe-modal-component
+    [detail]="shoes"
+    (update)="onUpdateShoe($event)">
+  </app-new-release-shoe-modal-component>
+</div>

--- a/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.html
+++ b/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.html
@@ -1,6 +1,6 @@
 <div>
   <app-new-release-shoe-modal-component
-    [detail]="shoes"
+    [shoesModel]="shoes"
     (update)="onUpdateShoe($event)">
   </app-new-release-shoe-modal-component>
 </div>

--- a/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.spec.ts
+++ b/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewReleaseShoeModalContainerComponent } from './new-release-shoe-modal-container.component';
+
+describe('NewReleaseShoeModalContainerComponent', () => {
+  let component: NewReleaseShoeModalContainerComponent;
+  let fixture: ComponentFixture<NewReleaseShoeModalContainerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NewReleaseShoeModalContainerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewReleaseShoeModalContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.ts
+++ b/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.ts
@@ -20,7 +20,7 @@ export class NewReleaseShoeModalContainerComponent implements OnInit {
   ngOnInit() {
     // getting the first shoe in the collection
     if(this.data.isEdit) {
-      this.shoeService.getShoes()
+      this.shoeService.getShoesNews()
                       .subscribe((snapshot) => {
                         snapshot.forEach(doc => {
                           if(doc.id === this.data.id) {

--- a/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.ts
+++ b/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.ts
@@ -36,8 +36,7 @@ export class NewReleaseShoeModalContainerComponent implements OnInit {
     if(this.data.isEdit) {
       this.shoeService.updateShoeNews(event, this.data.id);
     } else {
-      // this.shoeService.createShoesNews(event);
-      console.log(event);
+      this.shoeService.createShoesNews(event);
     }
   }
 

--- a/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.ts
+++ b/src/app/news/new-release-shoe-modal/containers/new-release-shoe-modal-container/new-release-shoe-modal-container.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { ShoeService } from '../../../../shoes-service/shoe.service';
+
+import { NewRelease } from '../../../../models/new-release.interface';
+
+@Component({
+  selector: 'app-new-release-shoe-modal-container',
+  templateUrl: './new-release-shoe-modal-container.component.html',
+  styleUrls: ['./new-release-shoe-modal-container.component.scss']
+})
+export class NewReleaseShoeModalContainerComponent implements OnInit {
+  shoes: NewRelease;
+
+  constructor(public dialogRef: MatDialogRef<NewReleaseShoeModalContainerComponent>, 
+              @Inject(MAT_DIALOG_DATA) public data: any,
+              private shoeService: ShoeService) {}
+  
+  ngOnInit() {
+    // getting the first shoe in the collection
+    if(this.data.isEdit) {
+      this.shoeService.getShoes()
+                      .subscribe((snapshot) => {
+                        snapshot.forEach(doc => {
+                          if(doc.id === this.data.id) {
+                            this.shoes = doc;
+                            return doc;
+                          }
+                        });
+                      })
+    }
+  }
+
+  onUpdateShoe(event: NewRelease) {
+    if(this.data.isEdit) {
+      this.shoeService.updateShoeNews(event, this.data.id);
+    } else {
+      // this.shoeService.createShoesNews(event);
+      console.log(event);
+    }
+  }
+
+}

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.html
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.html
@@ -1,24 +1,26 @@
-<h1 class="center">{{ shoeInfoModel.name }}</h1>
-<mat-grid-list *ngIf="shoeInfoModel" cols="4" rowHeight="100px">
-  <mat-grid-tile colspan="4" rowspan="6">
-    <img class="shoe-image" (click)="onClickCard(shoe.id)" mat-card-image src="{{shoeInfoModel.photoLink}}" alt="shoe image">
-  </mat-grid-tile>
-  <mat-grid-tile colspan="1" rowspan="3">
-    <mat-list>
-      <mat-list-item> {{ shoeInfoModel.brand }} </mat-list-item>
-      <mat-list-item> {{ shoeInfoModel.name }} </mat-list-item>
-      <mat-list-item> {{ shoeInfoModel.subName }} </mat-list-item>
-      <mat-list-item> {{ shoeInfoModel.releaseDate.toDate() | date: 'MM/dd/yyyy' }} </mat-list-item>
-     </mat-list>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="3">
-    <span>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Aliquam quo minus tempore veritatis quae, amet officiis adipisci, sunt quibusdam error laborum non molestias repellat itaque. Necessitatibus quaerat ea delectus facere.</span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="4" rowspan="3">
-    <mat-list>
-      <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
-      <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
-      <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
-     </mat-list>
-  </mat-grid-tile>
-</mat-grid-list>
+<div *ngIf="shoeInfoModel">
+  <h1 class="center">{{ shoeInfoModel.shoeDetails.name }}</h1>
+  <mat-grid-list cols="4" rowHeight="100px">
+    <mat-grid-tile colspan="4" rowspan="6">
+      <img class="shoe-image" (click)="onClickCard(shoe.id)" mat-card-image src="{{shoeInfoModel.shoeDetails.photoLink}}" alt="shoe image">
+    </mat-grid-tile>
+    <mat-grid-tile colspan="1" rowspan="3">
+      <mat-list>
+        <mat-list-item> {{ shoeInfoModel.shoeDetails.brand }} </mat-list-item>
+        <mat-list-item> {{ shoeInfoModel.shoeDetails.name }} </mat-list-item>
+        <mat-list-item> {{ shoeInfoModel.shoeDetails.subName }} </mat-list-item>
+        <mat-list-item> {{ shoeInfoModel.releaseDate.toDate() | date: 'MM/dd/yyyy' }} </mat-list-item>
+       </mat-list>
+    </mat-grid-tile>
+    <mat-grid-tile colspan="3" rowspan="3">
+      <span>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Aliquam quo minus tempore veritatis quae, amet officiis adipisci, sunt quibusdam error laborum non molestias repellat itaque. Necessitatibus quaerat ea delectus facere.</span>
+    </mat-grid-tile>
+    <mat-grid-tile colspan="4" rowspan="3">
+      <mat-list>
+        <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
+        <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
+        <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
+       </mat-list>
+    </mat-grid-tile>
+  </mat-grid-list>
+</div>

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.html
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.html
@@ -1,3 +1,24 @@
-<p>
-  {{ shoeInfoModel | json}}
-</p>
+<h1 class="center">{{ shoeInfoModel.name }}</h1>
+<mat-grid-list *ngIf="shoeInfoModel" cols="4" rowHeight="100px">
+  <mat-grid-tile colspan="4" rowspan="6">
+    <img class="shoe-image" (click)="onClickCard(shoe.id)" mat-card-image src="{{shoeInfoModel.photoLink}}" alt="shoe image">
+  </mat-grid-tile>
+  <mat-grid-tile colspan="1" rowspan="3">
+    <mat-list>
+      <mat-list-item> {{ shoeInfoModel.brand }} </mat-list-item>
+      <mat-list-item> {{ shoeInfoModel.name }} </mat-list-item>
+      <mat-list-item> {{ shoeInfoModel.subName }} </mat-list-item>
+      <mat-list-item> {{ shoeInfoModel.releaseDate.toDate() | date: 'MM/dd/yyyy' }} </mat-list-item>
+     </mat-list>
+  </mat-grid-tile>
+  <mat-grid-tile colspan="3" rowspan="3">
+    <span>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Aliquam quo minus tempore veritatis quae, amet officiis adipisci, sunt quibusdam error laborum non molestias repellat itaque. Necessitatibus quaerat ea delectus facere.</span>
+  </mat-grid-tile>
+  <mat-grid-tile colspan="4" rowspan="3">
+    <mat-list>
+      <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
+      <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
+      <mat-list-item> {{ shoeInfoModel.site }} </mat-list-item>
+     </mat-list>
+  </mat-grid-tile>
+</mat-grid-list>

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.html
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.html
@@ -1,0 +1,3 @@
+<p>
+  {{ shoeInfoModel | json}}
+</p>

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.scss
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.scss
@@ -1,0 +1,8 @@
+.center {
+    text-align: center;
+}
+
+.shoe-image {
+    width: 100%;
+    height: auto;
+}

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.spec.ts
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShoesPageComponent } from './shoes-page.component';
+
+describe('ShoesPageComponent', () => {
+  let component: ShoesPageComponent;
+  let fixture: ComponentFixture<ShoesPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ShoesPageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShoesPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.ts
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-shoes-page',
+  templateUrl: './shoes-page.component.html',
+  styleUrls: ['./shoes-page.component.scss']
+})
+export class ShoesPageComponent implements OnInit {
+
+  @Input()
+  shoeInfoModel;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/shoes-page/shoes-page-component/shoes-page.component.ts
+++ b/src/app/shoes-page/shoes-page-component/shoes-page.component.ts
@@ -6,13 +6,16 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./shoes-page.component.scss']
 })
 export class ShoesPageComponent implements OnInit {
-
+  
   @Input()
   shoeInfoModel;
 
   constructor() { }
 
   ngOnInit() {
+  }
+
+  ngOnChanges() {
   }
 
 }

--- a/src/app/shoes-page/shoes-page-container/shoes-page-container.component.html
+++ b/src/app/shoes-page/shoes-page-container/shoes-page-container.component.html
@@ -1,0 +1,4 @@
+<div class="shoes-page">
+  <app-shoes-page
+    [shoeInfoModel]="shoeInfo"></app-shoes-page>
+</div>

--- a/src/app/shoes-page/shoes-page-container/shoes-page-container.component.scss
+++ b/src/app/shoes-page/shoes-page-container/shoes-page-container.component.scss
@@ -1,0 +1,3 @@
+.shoes-page {
+    margin: 16px;
+}

--- a/src/app/shoes-page/shoes-page-container/shoes-page-container.component.spec.ts
+++ b/src/app/shoes-page/shoes-page-container/shoes-page-container.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShoesPageContainerComponent } from './shoes-page-container.component';
+
+describe('ShoesPageContainerComponent', () => {
+  let component: ShoesPageContainerComponent;
+  let fixture: ComponentFixture<ShoesPageContainerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ShoesPageContainerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShoesPageContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shoes-page/shoes-page-container/shoes-page-container.component.ts
+++ b/src/app/shoes-page/shoes-page-container/shoes-page-container.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import { ShoeService } from '../../shoes-service/shoe.service';
+
+@Component({
+  selector: 'app-shoes-page-container',
+  templateUrl: './shoes-page-container.component.html',
+  styleUrls: ['./shoes-page-container.component.scss']
+})
+export class ShoesPageContainerComponent implements OnInit {
+
+  shoeId: string;
+  shoeInfo;
+
+  constructor(private activatedRoute: ActivatedRoute, private shoeService: ShoeService) { }
+
+  ngOnInit() {
+      this.activatedRoute.queryParams.subscribe(params => {
+        this.shoeId = params['shoeId'];
+      });
+
+      this.shoeService.getShoesNews()
+        .subscribe((snapshot) => {
+          snapshot.forEach(doc => {
+            if(doc.id === this.shoeId) {
+              this.shoeInfo = doc;
+              return doc;
+            }
+          });
+      });
+  }
+
+}

--- a/src/app/shoes-service/shoe.service.ts
+++ b/src/app/shoes-service/shoe.service.ts
@@ -42,6 +42,19 @@ export class ShoeService {
                   );
   }
 
+  public createShoesNews(shoe: NewRelease) {
+    const id = this._db.createId();
+    this._db.collection('/news').doc('/release').collection('/sneakers').doc(id).set(shoe);
+  }
+
+  public updateShoeNews(shoe: NewRelease, shoeId: string){
+    this._db.collection('/news').doc('/release').collection('/sneakers').doc(shoeId).update(shoe);
+  }
+
+  public deleteShoeNews(shoeId: string){
+    this._db.collection('/news').doc('/release').collection('/sneakers').doc(shoeId).delete();
+  }
+
   public getShoes(): Observable<any[]> {
     return this._db.collection('/shoes').doc(`${this.userId}`).collection('/shoesCollection')
                   .snapshotChanges()

--- a/src/app/side-nav/side-nav.component.html
+++ b/src/app/side-nav/side-nav.component.html
@@ -11,7 +11,13 @@
   <a mat-list-item routerLink="/news" routerLinkActive="active">
     <button mat-icon-button><mat-icon>new_releases</mat-icon></button>New Releases
   </a>
-  <a mat-list-item routerLink="/dashboard" routerLinkActive="active">
-    <button mat-icon-button><mat-icon>dashboard</mat-icon></button>Dashboard
+  <a mat-list-item routerLinkActive="active">
+    <button mat-icon-button><mat-icon>face</mat-icon></button>About
   </a>
+  <a mat-list-item routerLinkActive="active">
+    <button mat-icon-button><mat-icon>contact_support</mat-icon></button>Contact
+  </a>
+  <!-- <a mat-list-item routerLink="/dashboard" routerLinkActive="active">
+    <button mat-icon-button><mat-icon>dashboard</mat-icon></button>Dashboard
+  </a> -->
 </mat-nav-list>

--- a/src/app/side-nav/side-nav.component.html
+++ b/src/app/side-nav/side-nav.component.html
@@ -9,34 +9,9 @@
 
 <mat-nav-list>
   <a mat-list-item routerLink="/news" routerLinkActive="active">
-    <button mat-icon-button><mat-icon>new_releases</mat-icon></button>News
+    <button mat-icon-button><mat-icon>new_releases</mat-icon></button>New Releases
   </a>
   <a mat-list-item routerLink="/dashboard" routerLinkActive="active">
     <button mat-icon-button><mat-icon>dashboard</mat-icon></button>Dashboard
   </a>
 </mat-nav-list>
-<!-- <ng-container *ngFor="let filter of filters | async; last as last">
-  <mat-list>
-    <h3 matSubheader>{{ filter.displayName }}</h3>
-
-    <ng-container *ngIf="filterState[filter.category] === ''; else chip">
-      <mat-list-item *ngFor="let val of filter.options">
-        <button mat-button class="list-button" (click)="changeFilter(filter.category, val)">
-          {{ val }}
-        </button>
-      </mat-list-item>
-    </ng-container>
-
-    <ng-template #chip>
-      <mat-chip-list>
-        <ng-container *ngFor="let val of filter.options">
-          <mat-chip *ngIf="filterState[filter.category] === val" (removed)="changeFilter(filter.category, '')">
-            {{val}}
-            <mat-icon matChipRemove>cancel</mat-icon>
-          </mat-chip>
-        </ng-container>
-      </mat-chip-list>
-    </ng-template>
-  </mat-list>
-  <mat-divider *ngIf="!last"></mat-divider>
-</ng-container> -->

--- a/src/app/side-nav/side-nav.component.ts
+++ b/src/app/side-nav/side-nav.component.ts
@@ -27,11 +27,6 @@ export class SideNavComponent implements OnInit{
     this.filterState = shoeFilterService.filterState;
     this.filters = shoeFilterService.filters;
   }
-  
-
-  changeFilter(category: string, option: Option) {
-    this.filterState[category] = option;
-  }
 
   updateSearchModel(value) {
     this.searchModel = value;


### PR DESCRIPTION
Allow admin to add sneakers to release News
For Admin user only**

- [x] Add Button in Release News page 
- [x] news/release/sneakers
- [x] delete
- [x] edit 
    - [x] edit release date is buggy
- [ ] only show for admin (add/edit/delete)
- [ ] POST needs to be protected for check for admin authentication (API)



Shoes page (product page)

- [x] Add new page & route (/sneaker/:id)
    - [x] Use Id in route params to do a GET on single sneaker
- [x] API will use sneaekerID to route to Shoes page
- [x] Release Date
    - [x] date/time of drop
- [x] Shoes info
    - [x] Name
    - [x] Type
    - [x] About
    - [x] Price
- [ ] Store info (add array) **work on making edit work bc its sending in empty array**
    - [ ] Category 
        - [ ] Raffles
        - [ ] Online drop
    - [ ] Display info:
        - [ ] store name
        - [ ] link
- [ ] Ability to add/edit/delete store info (admin only)